### PR TITLE
Add newly added tasks to undo.data

### DIFF
--- a/taskw/writing.py
+++ b/taskw/writing.py
@@ -78,7 +78,14 @@ def _task_remove(id, category):
 def _task_add(task, category):
     filename = category + '.data'
     config = taskw.reading.load_config()
+    location = config['data']['location']
 
     # Append the task
-    with open(os.path.join(config['data']['location'], filename), "a") as f:
+    with open(os.path.join(location, filename), "a") as f:
         f.writelines([task2str(task)])
+
+    # Add to undo.data
+    with open(os.path.join(location, 'undo.data'), "a") as f:
+        f.write("time %s\n" % str(int(time.time())))
+        f.write("new %s" % task2str(task))
+        f.write("---\n")


### PR DESCRIPTION
'task merge' doesn't work properly without the information in
undo.data

We still need to add completed/edited tasks to undo.data in the
following format:

time <timestamp>
old <old task info>
## new <new task info>
