### PR TITLE
Expand home directory

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -40,6 +40,7 @@ class TaskWarrior(object):
 
         def _load_tasks(filename):
             filename = os.path.join(self.config['data']['location'], filename)
+            filename = os.path.expanduser(filename)
             with open(filename, 'r') as f:
                 lines = f.readlines()
 


### PR DESCRIPTION
After joining the path elements to the database data, pass the path
to `os.path.expanduser`.

I was getting an error that `taskw` couldn't find my data because I use `~` 
in the path to my database.
