### PR TITLE
Fixed problems with quotes in task properties

### DIFF
--- a/taskw/utils.py
+++ b/taskw/utils.py
@@ -57,6 +57,7 @@ def decode_task(line):
 
     task = {}
     for key, value in re.findall(r'(\w+):"(.*?)(?<!\\)"', line):
+        value = value.replace('\\"', '"')  # unescape quotes
         task[key] = value
         for unsafe, safe in six.iteritems(decode_replacements):
             task[key] = task[key].replace(unsafe, safe)


### PR DESCRIPTION
E.g., 'Fix "quotes" in bugwarrior' would be read as
'Fix \"quotes\" in bugwarrior', now the quotes are
properly decoded.

Without this, bugwarrior would keep completing and adding bac tasks which have quotes in their descriptions, because remote_descs have clean quotes (returned by IssueService), while local_descs have quoted quotes in descriptions, e.g. \"; the descriptions wouldn't match and bugwarrior would think that the old issue was closed and a new one was added.

Bad.
