### PR TITLE
Import six

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -17,6 +17,7 @@ import pprint
 
 import taskw.utils
 
+import six
 from six import with_metaclass
 from six.moves import filter
 from six.moves import map


### PR DESCRIPTION
Unless `import six` is added, I get this error `NameError: global name 'six' is not defined`
