### PR TITLE
Fix test_updating_task

### DIFF
--- a/taskw/test/test_datas.py
+++ b/taskw/test/test_datas.py
@@ -143,6 +143,8 @@ class _BaseTestDB(object):
 
             # Also, experimental mode returns the id.  So, avoid comparing.
             del tasks['pending'][0]['id']
+            # Task 2.2.0 adds a "modified" field, so delete this.
+            del tasks['pending'][0]['modified']
         except:
             pass
 


### PR DESCRIPTION
Taskwarrior 2.2.0 adds a "modified" field; this needs to be deleted when comparing tasks in `test_updating_task`
