### PR TITLE
Refactor _load_tasks()

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -408,7 +408,7 @@ class TaskWarriorExperimental(TaskWarriorBase):
                 # fail in taskw.
                 search = kw[key][4:]
             else:
-                search = str(kw[key])
+                search = six.text_type(kw[key])
         task = subprocess.Popen([
             'task', 'rc:%s' % self.config_filename,
             'rc.verbose=nothing', search,


### PR DESCRIPTION
This is to fix issue #20. TaskWarrior and TaskWarriorExperimental now have their own versions of _load_tasks().

TaskWarriorExperimental should continue to work in the same way _except_ that searching by description has slightly changed due to a bug in TW (http://taskwarrior.org/issues/854). If you pass a description with parentheses (e.g. "(bw)") you'll get an error back from TW. I'm opening a pull request in Bugwarrior to deal with that problem.
