### PR TITLE
Allow passing tags as part of the task

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -45,6 +45,11 @@ class TaskWarriorBase(with_metaclass(abc.ABCMeta, object)):
         # task to it.
         task = {"description": description.strip()}
 
+        # Allow passing "tags" in as part of kw.
+        if 'tags' in kw and tags is None:
+            task['tags'] = tags
+            del(kw['tags'])
+
         if tags is not None:
             task['tags'] = tags
 


### PR DESCRIPTION
`_stub_task` currently accepts tags separately from `**kw`. It would be nice to be able to pass tags as part of `**kw` (for example, when calling `task_add()` in Bugwarrior.

In the future it would probably make sense to refactor `_stub_task()` so that it only accepts one parameter, `**kw`.

What do you think?
