### PR TITLE
Refactor such that all commands share a single interface.

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -371,8 +371,7 @@ class TaskWarriorExperimental(TaskWarriorBase):
     def _execute(self, *args):
         """ Execute a given taskwarrior command with arguments
 
-        Returns a 2-tuple having stdout and stderr results as its
-        elements in the first and second index respectively.
+        Returns a 2-tuple of stdout and stderr (respectively).
 
         """
         command = [


### PR DESCRIPTION
I know that I'd be a little frustrated if I saw a PR this big without a pre-existing conversation, so I do apologize for how big this PR is, but I promise that my intentions are good.

My goals in this refactoring were to:
- Centralize the `taskw` execution handling in a single location in the codebase (all calls can share `rc:` arguments).
- Push things a little tiny bit toward common conventions.

I had briefly planned making a few modifications to rearchitect things in somewhat more substantial ways -- perhaps separating `TaskWarriorExperimental` and the standard `TaskWarrior` subclasses into separate modules, and in a couple of situations, standardizing the signature of task alteration methods, but I think those might be a little too substantial for a hey-there-I-think-these-changes-might-be-helpful PR, and would be best posted (or not posted) after having at least a brief conversation.

Feel free to hit me up on freenode (i'm 'coddingtonbear' there) if you have any questions / would rather I not send in semi-aspirational patches of this nature.
