### PR TITLE
Switch .sync to also utilize common _execute interface.

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -429,11 +429,7 @@ class TaskWarriorShellout(TaskWarriorBase):
             raise UnsupportedVersionException(
                 "'sync' requires version 2.3 of taskwarrior or later."
             )
-        subprocess.Popen([
-            'task',
-            'rc:%s' % self.config_filename,
-            'sync',
-        ])
+        self._execute('sync')
 
     def load_tasks(self, command='all'):
         """ Returns a dictionary of tasks for a list of command."""


### PR DESCRIPTION
Sorry for not noticing this when I altered everything to use `_execute`!
- Fixes `sync` such that it uses `_execute` machinery.  Also thereby fixes a bug in which calling `load_tasks` immediately following `sync` may not show tasks gathered during the aforementioned `sync` due to the fact that `sync` previously would not wait for spawned subprocess to end. (`_execute` automatically waits since `communicate` blocks until process end)
