### PR TITLE
Return stdout or stderr from `task_info`.

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -639,8 +639,7 @@ class TaskWarriorShellout(TaskWarriorBase):
 
     def task_info(self, **kw):
         id, task = self.get_task(**kw)
-        self._get_json('info', id)
-        out, err = info.communicate()
+        out, err = self._execute(id, 'info')
         if err:
             return err
         return out


### PR DESCRIPTION
This is definitely something I broke during the process of converting things to use the shared `_execute` interface; sorry about that.

(I just happened to notice that my linter highlighted `info` as undefined while working on the previous PR).
