### PR TITLE
Convert `None` into an empty string

### DIFF
--- a/taskw/utils.py
+++ b/taskw/utils.py
@@ -54,7 +54,9 @@ def encode_task_experimental(task):
     if 'tags' in task:
         task['tags'] = ','.join(task['tags'])
     for k in task:
-        if isinstance(task[k], datetime.datetime):
+        if task[k] is None:
+            task[k] = ''
+        elif isinstance(task[k], datetime.datetime):
             if not task[k].tzinfo:
                 #  Dates not having timezone information should be
                 #  assumed to be in local time


### PR DESCRIPTION
Without this fix, should one set, for example, the field `date` to the value `None`, we will convert the value `None` into the string `"None"`, which will not actually set the field properly.
