### PR TITLE
Raise an exception when taskwarrior has a non-zero return status.

### DIFF
--- a/taskw/exceptions.py
+++ b/taskw/exceptions.py
@@ -1,0 +1,8 @@
+
+
+class TaskwarriorError(Exception):
+    def __init__(self, stderr, stdout, code):
+        self.stderr = stderr.strip()
+        self.stdout = stdout.strip()
+        self.code = code
+        super(TaskwarriorError, self).__init__(self.stderr)

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -24,6 +24,7 @@ import json
 import pprint
 
 import taskw.utils
+from taskw.exceptions import TaskwarriorError
 
 import six
 from six import with_metaclass
@@ -420,11 +421,15 @@ class TaskWarriorShellout(TaskWarriorBase):
             'rc.verbose=nothing',
             'rc.confirmation=no',
         ] + [six.text_type(arg) for arg in args]
-        return subprocess.Popen(
+        proc = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-        ).communicate()
+        )
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise TaskwarriorError(stderr, stdout, proc.returncode)
+        return stdout, stderr
 
     def _get_json(self, *args):
         encoded = self._execute(*args)[0]


### PR DESCRIPTION
Feel free to reject this pull request if this doesn't line-up with your model for how things should work -- I promise I won't be offended.

When working on inthe.am, I needed to be aware of situations when taskwarrior had exited with an error code, so I [subclassed your TaskWarriorShellout](https://github.com/latestrevision/inthe.am/blob/master/inthe_am/taskmanager/taskwarrior_client.py#L66) in my application to add this feature.  Initially, I was going to leave this in my subclass rather than trying to push this change upstream.

Upon further consideration, I decided to send you this PR.  It seems likely that, rather than inspecting the output of the command to see if it was successful, this might provide a more direct way of becoming aware that one's task did not execute successfully.

Cheers,
Adam
