### PR TITLE
Raise an exception if we can't parse configuration; ignore simple config...

### DIFF
--- a/taskw/taskrc.py
+++ b/taskw/taskrc.py
@@ -48,6 +48,16 @@ class TaskRc(dict):
         for part in key_parts[0:-1]:
             if part not in cursor:
                 cursor[part] = {}
+            # Unfortunately, collapsing our configuration into a dict
+            # has some downsides -- we can't store both of the following
+            # simultaneously::
+            #
+            #   color = on
+            #   color.header = something
+            #
+            # So we err on the side of storing more.
+            if not isinstance(cursor[part], dict):
+                cursor[part] = {}
             cursor = cursor[part]
         cursor[key_parts[-1]] = value
         return config

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -441,14 +441,7 @@ class TaskWarriorShellout(TaskWarriorBase):
         super(TaskWarriorShellout, self).__init__(config_filename)
         self.config_overrides = config_overrides if config_overrides else {}
         self._marshal = marshal
-        try:
-            self.config = TaskRc(config_filename, overrides=config_overrides)
-        except:
-            logger.exception(
-                "Error encountered while loading configuration file "
-                "at '%s'",
-                config_filename,
-            )
+        self.config = TaskRc(config_filename, overrides=config_overrides)
 
     def get_configuration_override_args(self):
         config_overrides = self.DEFAULT_CONFIG_OVERRIDES.copy()


### PR DESCRIPTION
... values to allow storing complex ones.

I'm a little sad about this one, to be honest, but I think it's the only way we can go while converting configuration entries into dictionaries.

We do, though have an out for the future, if necessary, but before I commit to making that a possibility, I think this is a reasonable stopgap.
