### PR TITLE
Make annotations really be strings, just special ones.

### DIFF
--- a/taskw/fields/annotationarray.py
+++ b/taskw/fields/annotationarray.py
@@ -18,7 +18,7 @@ class Annotation(six.text_type):
 
     def __init__(self, description, entry=None):
         self._entry = entry
-        super(Annotation, self).__init__(description)
+        super(Annotation, self).__init__()
 
     @property
     def entry(self):


### PR DESCRIPTION
This was actually my original approach on this, but I couldn't get it to work yesterday because I made a foolish mistake.

I had accidentally typed the private property's name to be `entry` rather than `_entry` -- which threw an error indicating that that property could not be set.  I took this to be a side-effect of the fact that strings do not have a `__dict__`, and arbitrary attributes cannot be added (which is true for bare strings -- but subclasses _should_ be immune).  As it turns out, it was just a name collision with an actual read-only `@property` named `entry` that I had added to the class.  Derp.
