### PR TITLE
Do not allow taskwarrior to attempt to parse the string passed-in to denotate.

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -686,6 +686,7 @@ class TaskWarriorShellout(TaskWarriorBase):
         self._execute(
             task['uuid'],
             'denotate',
+            '--',
             annotation
         )
         id, denotated_task = self.get_task(uuid=task[six.u('uuid')])


### PR DESCRIPTION
We're already doing this for `annotate`, but the `--` feature is also useful here.
