### PR TITLE
Fixing a bug in which, while merging two configuration trees, we encount...

### DIFF
--- a/taskw/taskrc.py
+++ b/taskw/taskrc.py
@@ -21,6 +21,24 @@ def sanitize(line):
 
 
 class TaskRc(dict):
+    """ Access the user's taskRC using a dictionary-like interface.
+
+    There is a downside, though:
+
+    Unfortunately, collapsing our configuration into a dict has a
+    jarring limitation -- we can't store both of the following
+    simultaneously:
+
+    * color = on
+    * color.header = something
+
+    In this module, we err on the side of storing subkeys rather than the
+    actual value in situations where both are necessary.
+
+    Please forgive me.
+
+    """
+
     UDA_TYPE_MAP = {
         'date': DateField,
         'duration': DurationField,
@@ -48,14 +66,8 @@ class TaskRc(dict):
         for part in key_parts[0:-1]:
             if part not in cursor:
                 cursor[part] = {}
-            # Unfortunately, collapsing our configuration into a dict
-            # has some downsides -- we can't store both of the following
-            # simultaneously::
-            #
-            #   color = on
-            #   color.header = something
-            #
-            # So we err on the side of storing more.
+            # See class docstring -- we can't store both a value and
+            # a dict in the same place.
             if not isinstance(cursor[part], dict):
                 cursor[part] = {}
             cursor = cursor[part]
@@ -67,6 +79,10 @@ class TaskRc(dict):
             left = {}
 
         for key, value in right.items():
+            # See class docstring -- we can't store both a value and
+            # a dict in the same place.
+            if not isinstance(left, dict):
+                left = {}
             if isinstance(value, dict):
                 left[key] = self._merge_trees(left.get(key), value)
             else:


### PR DESCRIPTION
...er the dict/string problem.  Fixes #65.

I kind of want to pave this over in the future by going back to dot-path configuration lookups (rather than storing as a dictionary), but that would be a fairly severe, backward-incompatible change :-/. 

Perhaps this future alternative:
1. Still allow people to access configuration values as dictionary keys, but
2. Add a method to the config object (perhaps `.get_value(dot_path)`) accepting the dot path to a configuration value that you'd like returned.

For now, though, I think this is the best way to go forward.
