### PR TITLE
Replace attr.is:value queries with attr == "value".

### DIFF
--- a/taskw/test/test_datas.py
+++ b/taskw/test/test_datas.py
@@ -582,3 +582,25 @@ class TestDBShellout(_BaseTestDB):
         eq_(len(results), 1)
         task = results[0]
         eq_(task['someurl'], arbitrary_url)
+
+    def test_add_and_retrieve_uda_string_url_in_parens(self):
+        arbitrary_url = "http://www.someurl.com/1084/"
+
+        self.tw.config_overrides['uda'] = {
+            'someurl': {
+                'label': 'Some URL',
+                'type': 'string'
+            }
+        }
+        self.tw.task_add(
+            "foobar",
+            someurl=arbitrary_url,
+        )
+        results = self.tw.filter_tasks({
+            'and': [
+                ('someurl.is', arbitrary_url),
+            ],
+        })
+        eq_(len(results), 1)
+        task = results[0]
+        eq_(task['someurl'], arbitrary_url)

--- a/taskw/utils.py
+++ b/taskw/utils.py
@@ -14,6 +14,8 @@ import dateutil.tz
 import pytz
 import six
 
+from distutils.version import LooseVersion
+
 
 DATE_FORMAT = '%Y%m%dT%H%M%SZ'
 
@@ -97,12 +99,20 @@ def encode_query(value, version, query=True):
                 ])
             )
         else:
-            args.append(
-                '%s:%s' % (
-                    k,
-                    encode_task_value(k, v, query=query)
+            if k.endswith(".is") and version >= LooseVersion('2.4'):
+                args.append(
+                    '%s == "%s"' % (
+                        k[:-3],
+                        encode_task_value(k, v, query=query)
+                    )
                 )
-            )
+            else:
+                args.append(
+                    '%s:%s' % (
+                        k,
+                        encode_task_value(k, v, query=query)
+                    )
+                )
 
     return args
 


### PR DESCRIPTION
This came up as a result of discussions near the release of
taskwarrior-2.4.1.  It turns out that the 'attr.modifier:value' form of
querying is deprecated.  It won't go away for a long time, but we need
to eventually move to 'attr == "value"'.

This approach makes taskw perhaps more "helpful" than it should be in
that the query that the user pretty explicitly specifies to
python-taskw, gets changed under the covers before it is handed off to
taskwarrior.

This adds an extra test that failed before the code in
``taskw/utils.py`` was introduced.  That new code change makes the test
pass (and introduces no other new failures in the test suite).  Tox is
happy on a local run.