### PR TITLE
Strip form feed/bell chars

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -487,6 +487,12 @@ class TaskWarriorShellout(TaskWarriorBase):
         except UnicodeDecodeError as e:
             stderr = kitchen.text.converters.to_unicode(stderr)
 
+        # strip any crazy terminal escape characters like bells, backspaces,
+        # and form feeds
+        for c in ('\a', '\b', '\f'):
+            stdout = stdout.replace(c, '?')
+            stderr = stderr.replace(c, '?')
+
         return stdout, stderr
 
     def _get_json(self, *args):


### PR DESCRIPTION
A task body contained a `\a` character, which caused taskw to crash when
parsing the JSON output when reading tasks.