### PR TITLE
Downgrade string coercion from warning to debug.

### DIFF
--- a/taskw/fields/string.py
+++ b/taskw/fields/string.py
@@ -26,7 +26,7 @@ class StringField(Field):
             return value
         if not isinstance(value, six.string_types):
             string_value = six.text_type(value)
-            logger.warning(
+            logger.debug(
                 "Value %s serialized to string as '%s'",
                 repr(value),
                 string_value


### PR DESCRIPTION
The warning seems inappropriate as I don't know why this should be
inherently concerning. My motivation is to eliminate all the annoying
`WARNING:taskw.fields.string:Value 1 serialized to string as '1'` lines
output by a `bugwarrior-pull`. Looks like @coddingtonbear wrote this so
perhaps he'll set me straight.