### PR TITLE
Fix bugwarrior issue #393

### DIFF
--- a/taskw/test/test_utils.py
+++ b/taskw/test/test_utils.py
@@ -11,7 +11,8 @@ from taskw.utils import (
     decode_task,
     encode_task,
     encode_task_experimental,
-    DATE_FORMAT
+    DATE_FORMAT,
+    clean_ctrl_chars,
 )
 
 TASK = {'description': "task 2 http://www.google.com/",
@@ -200,3 +201,14 @@ class TestUtils(object):
         actual_overrides = convert_dict_to_override_args(overrides)
 
         eq_(set(actual_overrides), set(expected_overrides))
+
+
+class TestCleanExecArg(object):
+    def test_clean_null(self):
+        eq_(b"", clean_ctrl_chars(b"\x00"))
+
+    def test_all_ctrl_chars(self):
+        """ Test that most (but not all) control characters are removed """
+        # input = bytes(range(0x20))
+        input = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f' # For python 2 compatibility
+        eq_(b"\t\n\v\f\r", clean_ctrl_chars(input))

--- a/taskw/test/test_warrior.py
+++ b/taskw/test/test_warrior.py
@@ -1,0 +1,39 @@
+import tempfile
+import os
+import shutil
+
+from taskw.warrior import TaskWarrior
+
+
+class TestTaskWarrior(object):
+    def setUp(self):
+        self.taskdata = tempfile.mkdtemp()
+        taskrc = os.path.join(os.path.dirname(__file__), 'data/empty.taskrc')
+        self.taskwarrior = TaskWarrior(
+            config_filename=taskrc,
+            config_overrides={'data.location': self.taskdata})
+        # Just a sanity check to make sure that after the setup, the list of
+        # tasks is empty, otherwise we are probably using the current user's
+        # TASKDATA and we should not continue.
+        assert self.taskwarrior.load_tasks() == {'completed': [], 'pending': []}
+
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.taskdata)
+
+    def test_add_task_foobar(self):
+        """ Add a task with description 'foobar' and checks that the task is
+        indeed created """
+        self.taskwarrior.task_add("foobar")
+        tasks = self.taskwarrior.load_tasks()
+        assert len(tasks['pending']) == 1
+        assert tasks['pending'][0]['description'] == 'foobar'
+
+    def test_add_task_null_char(self):
+        """ Try adding a task where the description contains a NULL character
+        (0x00). This should not fail but instead simply add a task with the
+        same description minus the NULL character """
+        self.taskwarrior.task_add("foo\x00bar")
+        tasks = self.taskwarrior.load_tasks()
+        assert len(tasks['pending']) == 1
+        assert tasks['pending'][0]['description'] == 'foobar'

--- a/taskw/utils.py
+++ b/taskw/utils.py
@@ -261,3 +261,10 @@ def convert_dict_to_override_args(config, prefix=''):
             right = v if ' ' not in v else '"%s"' % v
             args.append('='.join([left, right]))
     return args
+
+
+CTRLCHAR = re.compile(b"[\x00-\x08\x0e-\x1f]")
+
+def clean_ctrl_chars(s):
+    """ Clean string removing most (but not all) control characters """
+    return CTRLCHAR.sub(b'', s)

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -454,9 +454,11 @@ class TaskWarriorShellout(TaskWarriorBase):
         )
 
         # subprocess is expecting bytestrings only, so nuke unicode if present
+        # and remove control characters
         for i in range(len(command)):
             if isinstance(command[i], six.text_type):
-                command[i] = command[i].encode('utf-8')
+                command[i] = (
+                    taskw.utils.clean_ctrl_chars(command[i].encode('utf-8')))
 
         try:
             proc = subprocess.Popen(


### PR DESCRIPTION
Remove the control characters in the command executed in
`TaskWarriorShellout._execute`.

Also add some integration test for the task_add method to make sure that
this fixes issue ralphbean/bugwarrior#393.