### PR TITLE
Improve configuration parsing

### DIFF
--- a/taskw/taskrc.py
+++ b/taskw/taskrc.py
@@ -114,7 +114,7 @@ class TaskRc(dict):
                         )
                 else:
                     try:
-                        left, right = line.split('=')
+                        left, right = line.split('=', 1)
                         key = left.strip()
                         value = right.strip()
                         config = self._add_to_tree(config, key, value)


### PR DESCRIPTION
Previously parsing the configuration failed when a configuration option (e.g. a filter) contains an equal sign ('='). In my case this was something like `report.foo.filter=foo != bar`.