### PR TITLE
Add alternative Task constructor for use with hooks

### DIFF
--- a/taskw/task.py
+++ b/taskw/task.py
@@ -95,14 +95,15 @@ class Task(dict):
     @classmethod
     def from_input(cls, input_file=sys.stdin, modify=None, udas=None):
         """
-        Creates a Task object, directly from the stdin, by reading one line.
-        If modify=True, two lines are used, first line interpreted as the
-        original state of the Task object, and second line as its new,
-        modified value. This is consistent with the TaskWarrior's hook
-        system.
+        Create a Task directly from stdin by reading one line. If modify=True,
+        two lines are expected, which is consistent with the Taskwarrior hook
+        system. The first line is interpreted as the original state of the Task,
+        and the second one as the new, modified state.
 
-        Input_file argument can be used to specify the input file,
-        but defaults to sys.stdin.
+        :param input_file: Input file. Defaults to sys.stdin.
+        :param modify: Flag for on-modify hook event.
+        :param udas: Taskrc udas
+        :return Task
         """
         # Detect the hook type if not given directly
         name = os.path.basename(sys.argv[0])

--- a/taskw/task.py
+++ b/taskw/task.py
@@ -1,4 +1,7 @@
+import json
 import logging
+import os
+import sys
 
 import six
 
@@ -88,6 +91,28 @@ class Task(dict):
             processed[k] = cls._serialize(k, v, fields)
 
         return cls(processed, udas)
+
+    @classmethod
+    def from_input(cls, input_file=sys.stdin, modify=None, udas=None):
+        """
+        Creates a Task object, directly from the stdin, by reading one line.
+        If modify=True, two lines are used, first line interpreted as the
+        original state of the Task object, and second line as its new,
+        modified value. This is consistent with the TaskWarrior's hook
+        system.
+
+        Input_file argument can be used to specify the input file,
+        but defaults to sys.stdin.
+        """
+        # Detect the hook type if not given directly
+        name = os.path.basename(sys.argv[0])
+        modify = name.startswith('on-modify') if modify is None else modify
+
+        original_task = input_file.readline().strip()
+        if modify:
+            modified_task = input_file.readline().strip()
+            return cls(json.loads(modified_task), udas=udas)
+        return cls(json.loads(original_task), udas=udas)
 
     @classmethod
     def _get_converter_for_field(cls, field, default=None, fields=None):

--- a/taskw/task.py
+++ b/taskw/task.py
@@ -93,7 +93,7 @@ class Task(dict):
         return cls(processed, udas)
 
     @classmethod
-    def from_input(cls, input_file=sys.stdin, modify=None, udas=None):
+    def from_input(cls, input_file=sys.stdin, modify=False, udas=None):
         """
         Create a Task directly from stdin by reading one line. If modify=True,
         two lines are expected, which is consistent with the Taskwarrior hook
@@ -101,14 +101,10 @@ class Task(dict):
         and the second one as the new, modified state.
 
         :param input_file: Input file. Defaults to sys.stdin.
-        :param modify: Flag for on-modify hook event.
-        :param udas: Taskrc udas
+        :param modify: Flag for on-modify hook event. Defaults to False.
+        :param udas: Taskrc udas. Defaults to None.
         :return Task
         """
-        # Detect the hook type if not given directly
-        name = os.path.basename(sys.argv[0])
-        modify = name.startswith('on-modify') if modify is None else modify
-
         original_task = input_file.readline().strip()
         if modify:
             modified_task = input_file.readline().strip()

--- a/taskw/test/test_task.py
+++ b/taskw/test/test_task.py
@@ -152,7 +152,6 @@ class TestTaskMarshalling(TestCase):
             'urgency': 10,
             'uuid': str(uuid.uuid4()),
         }
-        task = Task(arbitrary_serialized_data)
         expected_result = arbitrary_serialized_data
 
         after_composition = Task(

--- a/taskw/test/test_task.py
+++ b/taskw/test/test_task.py
@@ -1,18 +1,13 @@
 import copy
 import datetime
-import sys
 import uuid
+from unittest import TestCase
 
 import pytz
 import six
 from dateutil.tz import tzutc
 
 from taskw.task import Task
-
-if sys.version_info >= (2, 7):
-    from unittest import TestCase
-else:
-    from unittest2 import TestCase
 
 
 class TestTaskDirtyability(TestCase):

--- a/taskw/test/test_task.py
+++ b/taskw/test/test_task.py
@@ -189,12 +189,16 @@ class TestTaskMarshalling(TestCase):
             ]),
         )
 
-        task = Task.from_input(input_file=input_add_data)
-        assert task.get('description') == "Go to Camelot"
-        assert task.get('entry') == datetime.datetime(2018, 6, 18, 3, 2, 42, tzinfo=tzutc())
-        assert task.get('status') == "pending"
-        assert task.get('start') == datetime.datetime(2018, 10, 12, 11, 6, 5, tzinfo=tzutc())
-        assert task.get('uuid') == uuid.UUID("daa3ff05-f716-482e-bc35-3e1601e50778")
+        on_add_task = Task.from_input(input_file=input_add_data)
+        assert on_add_task.get('description') == "Go to Camelot"
+        assert on_add_task.get('entry') == datetime.datetime(2018, 6, 18, 3, 2, 42, tzinfo=tzutc())
+        assert on_add_task.get('status') == "pending"
+        assert on_add_task.get('start') == datetime.datetime(2018, 10, 12, 11, 6, 5, tzinfo=tzutc())
+        assert on_add_task.get('uuid') == uuid.UUID("daa3ff05-f716-482e-bc35-3e1601e50778")
 
-        task = Task.from_input(input_file=input_modify_data, modify=True)
-        assert task.get('description') == "Go to Camelot again"
+        on_modify_task = Task.from_input(input_file=input_modify_data, modify=True)
+        assert on_modify_task.get('description') == "Go to Camelot again"
+        assert on_modify_task.get('entry') == datetime.datetime(2018, 6, 18, 3, 2, 42, tzinfo=tzutc())
+        assert on_modify_task.get('status') == "pending"
+        assert on_modify_task.get('start') == datetime.datetime(2018, 10, 12, 11, 6, 5, tzinfo=tzutc())
+        assert on_modify_task.get('uuid') == uuid.UUID("daa3ff05-f716-482e-bc35-3e1601e50778")


### PR DESCRIPTION
Patch adding an alternative `from_input` `Task` constructor for use with Taskwarrior's [hooks v2 API](https://taskwarrior.org/docs/hooks2.html).
