### PR TITLE
Fix TypeError in str(TaskwarriorError(...))

### DIFF
--- a/taskw/exceptions.py
+++ b/taskw/exceptions.py
@@ -18,4 +18,4 @@ class TaskwarriorError(Exception):
         )
 
     def __str__(self):
-        return self.__unicode__().encode(sys.getdefaultencoding(), 'replace')
+        return self.__unicode__().encode(sys.getdefaultencoding(), 'replace').decode(sys.getdefaultencoding())


### PR DESCRIPTION
`__str__` should return a string, but `string.encode(...)` returns bytes instead. This commit fixes it by decoding the bytes back to a string.

Fixes: #125