### PR TITLE
warrior.py: Fix Python 3 detecting missing task

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -554,7 +554,7 @@ class TaskWarriorShellout(TaskWarriorBase):
                 stdout=subprocess.PIPE
             ).communicate()[0]
         except OSError as e:
-            if 'No such file or directory' in e:
+            if 'No such file or directory' in str(e):
                 raise OSError("Unable to find the 'task' command-line tool.")
             raise
         return LooseVersion(taskwarrior_version.decode())


### PR DESCRIPTION
Replaces `'foo' in e` with `'foo' in str(e)`.

Fixes https://github.com/ralphbean/taskw/issues/127