### PR TITLE
Fixes parsing of rc options containing '='

### DIFF
--- a/taskw/taskrc.py
+++ b/taskw/taskrc.py
@@ -100,7 +100,7 @@ class TaskRc(dict):
                     continue
                 if line.startswith('include '):
                     try:
-                        left, right = line.split(' ')
+                        left, right = line.split(' ', maxsplit=1)
                         config = self._merge_trees(
                             config,
                             TaskRc(right.strip())


### PR DESCRIPTION
If an option, eg an alias, contains an '=', then taskw will fail with a ValueError of too many values to unpack.