### PR TITLE
Fix importing taskw without taskwarrior

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -19,7 +19,6 @@ import time
 import uuid
 import subprocess
 import json
-import errno
 
 import kitchen.text.converters
 
@@ -467,10 +466,10 @@ class TaskWarriorShellout(TaskWarriorBase):
                 stderr=subprocess.PIPE,
             )
             stdout, stderr = proc.communicate()
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                raise OSError("Unable to find the 'task' command-line tool.")
-            raise
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                "Unable to find the 'task' command-line tool."
+            )
 
         if proc.returncode != 0:
             raise TaskwarriorError(command, stderr, stdout, proc.returncode)
@@ -541,8 +540,8 @@ class TaskWarriorShellout(TaskWarriorBase):
         """
         try:
             return cls.get_version() > LooseVersion('2')
-        except OSError:
-            # OSError is raised if subprocess.Popen fails to find
+        except FileNotFoundError:
+            # FileNotFound is raised if subprocess.Popen fails to find
             # the executable.
             return False
 
@@ -553,10 +552,10 @@ class TaskWarriorShellout(TaskWarriorBase):
                 ['task', '--version'],
                 stdout=subprocess.PIPE
             ).communicate()[0]
-        except OSError as e:
-            if 'No such file or directory' in e:
-                raise OSError("Unable to find the 'task' command-line tool.")
-            raise
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                "Unable to find the 'task' command-line tool."
+            )
         return LooseVersion(taskwarrior_version.decode())
 
     def sync(self, init=False):


### PR DESCRIPTION
Importing taskw without having taskwarrior installed raises an exception (tested with CPython3.7):
```
❯❯❯ python -c 'import taskw.warrior'
Traceback (most recent call last):
  File "/src/taskw/warrior.py", line 554, in get_version
    stdout=subprocess.PIPE
  File "/usr/local/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.7/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'task': 'task'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/src/taskw/__init__.py", line 1, in <module>
    from taskw.warrior import (
  File "/src/taskw/warrior.py", line 916, in <module>
    if TaskWarriorShellout.can_use():
  File "/src/taskw/warrior.py", line 543, in can_use
    return cls.get_version() > LooseVersion('2')
  File "/src/taskw/warrior.py", line 557, in get_version
    if 'No such file or directory' in e:
TypeError: argument of type 'FileNotFoundError' is not iterable
```

This fixes the issue by refactoring exception handling in `taskw/warrior.py` to use `FileNotFoundError` instead of matching on the string.

It is however a python 3.3+ solution and I just realized you advertise legacy python compatibility in `setup.py`.  But since it's two weeks to 2020 maybe that's ok? :crossed_fingers: 
