### PR TITLE
Closes ralphbean/bugwarrior#729

### DIFF
--- a/taskw/fields/choice.py
+++ b/taskw/fields/choice.py
@@ -34,7 +34,9 @@ class ChoiceField(Field):
             raise ValueError(
                 "'%s' is not a valid choice; choices: %s" % (
                     value,
-                    self._choices,
+                    # None in _choices represents an empty string in config
+                    # so including '' in err instead makes more sense
+                    ['' if c is None else c for c in self._choices],
                 )
             )
         return value


### PR DESCRIPTION
Improves error message when user sets service.default_priority incorrectly by printing the valid config options

Instead of giving the error message
```ValueError: 'None' is not a valid choice; choices: [None, 'H', 'M', 'L']```
Gives error
```ValueError: 'None' is not a valid choice; choices: ['', 'H', 'M', 'L']```

None is not a valid config option, rather it represents the config option '' so '' should be included in the error message not None