### PR TITLE
Add Python 3.9 and Taskwarrior 2.5.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         taskwarrior-version: [2.5.0, 2.5.1]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
-        taskwarrior-version: [2.5.0, 2.5.1]
+        taskwarrior-version: [2.5.0, 2.5.1, 2.5.2]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}-tw{250,251}
+envlist = py{27,35,36,37,38,39}-tw{250,251}
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
@@ -9,6 +9,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,39}-tw{250,251}
+envlist = py{27,35,36,37,38,39}-tw{250,251,252}
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
@@ -16,6 +16,7 @@ deps =
 setenv = 
     tw250: TASKWARRIOR=v2.5.0
     tw251: TASKWARRIOR=v2.5.1
+    tw252: TASKWARRIOR=v2.5.2
 sitepackages = False
 commands =
     {toxinidir}/.tox_build_taskwarrior.sh "{envdir}" "{toxinidir}"


### PR DESCRIPTION
Add Python 3.9 and Taskwarrior 2.5.2 to `tox.ini` and GitHub Actions tests.

Did you consider dropping Python 2.7 and 3.5 support? They are after EOL.