### PR TITLE
rc.verbose=new-uuid only works if it is the first paramater for taskwarrior 2.5.2

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -412,10 +412,10 @@ class TaskWarriorShellout(TaskWarriorBase):
     and https://github.com/ralphbean/taskw/issues/30 for more.
     """
     DEFAULT_CONFIG_OVERRIDES = {
+        'verbose': 'nothing',
         'json': {
             'array': 'TRUE'
         },
-        'verbose': 'nothing',
         'confirmation': 'no',
         'dependency': {
             'confirmation': 'no',


### PR DESCRIPTION
There is a bug in version of taskwarrior that the rc.verbose=new-uuid argument will only work if it is the first argument.

See GothenburgBitFactory/taskwarrior#1953

This change moves the 'verbose' config option to be first in DEFAULT_CONFIG_OVERRIDES.

Without this change the test suite fails and it isn't possible to create new tasks.