### PR TITLE
Don't pass urgency:0 to taskwarrior 2.5.2 for task modify

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -799,6 +799,9 @@ class TaskWarriorShellout(TaskWarriorBase):
             if 'annotations' in task_to_modify:
                 del task_to_modify['annotations']
 
+        if task_to_modify.get('urgency') == 0:
+            del task_to_modify['urgency']
+
         modification = taskw.utils.encode_task_experimental(task_to_modify)
         # Only try to modify the task if there are changes to post here
         # (changes *might* just be in annotations).


### PR DESCRIPTION
When modifying a task in taskwarrior 2.5.2 it was returning this error:

  The 'urgency' attribute does not allow a value of '0'.

The solution is to drop the urgency argument if the value is 0 when calling task modify.