### PR TITLE
Filter tasks needs quotes in taskwarrior 2.5.2

### DIFF
--- a/taskw/test/test_datas.py
+++ b/taskw/test/test_datas.py
@@ -383,7 +383,7 @@ class TestDBShellout(_BaseTestDB):
         self.tw.task_add("foobar2")
         self.tw.task_add("foobar+")
         tasks = self.tw.filter_tasks({
-            'description.contains': 'foobar+',
+            'description.contains': '"foobar+"',
         })
         assert len(tasks) == 1
         assert tasks[0]['id'] == 3
@@ -393,7 +393,7 @@ class TestDBShellout(_BaseTestDB):
         self.tw.task_add("foobar2")
         self.tw.task_add("foobar-")
         tasks = self.tw.filter_tasks({
-            'description.contains': 'foobar-',
+            'description.contains': '"foobar-"',
         })
         assert len(tasks) == 1
         assert tasks[0]['id'] == 3
@@ -451,7 +451,7 @@ class TestDBShellout(_BaseTestDB):
         self.tw.task_add("foobar2")
         self.tw.task_add("foo/bar")
         tasks = self.tw.filter_tasks({
-            'description.contains': 'foo/bar',
+            'description.contains': '"foo/bar"',
         })
         assert len(tasks) == 1
         assert tasks[0]['id'] == 3


### PR DESCRIPTION
With taskwarrior 2.5.2 some tests of filter_tasks with description.contains fail.

-  'foobar+' returns 'The expression could not be evaluated.'
-  'foobar-' returns 'The expression could not be evaluated.'
-  'foo/bar' returns 'Cannot divide real numbers by strings'

The solution is to quote the filter parameters in the tests.