### PR TITLE
[superseded] RcFile: _read: try taskrc directory when trying to load includes

### DIFF
--- a/taskw/taskrc.py
+++ b/taskw/taskrc.py
@@ -39,6 +39,7 @@ class TaskRc(dict):
 
     """
 
+    rcdir = None
     UDA_TYPE_MAP = {
         'date': DateField,
         'duration': DurationField,
@@ -54,6 +55,8 @@ class TaskRc(dict):
                     path
                 )
             )
+            if not self.rcdir:
+                TaskRc.rcdir = os.path.dirname(os.path.realpath(self.path))
             config = self._read(self.path)
         else:
             self.path = None
@@ -92,6 +95,17 @@ class TaskRc(dict):
 
     def _read(self, path):
         config = {}
+        if not os.path.exists(path):
+            # include path may be given relative to dir of rcfile
+            oldpath = path
+            path = "%s/%s" % (TaskRc.rcdir, path)
+            if not os.path.exists(path):
+                logger.error(
+                    "rcfile does not exist, tried %s and %s",
+                    oldpath, path
+                )
+                raise FileNotFoundError
+
         with open(path, 'r') as config_file:
             for raw_line in config_file.readlines():
                 line = sanitize(raw_line)


### PR DESCRIPTION
Taskwarrior can have 'include' directives in the rcfile which use pathnames relative to the rcfile location.  Currently in taskw library, these will fail because the file is opened without attempting to search for it or qualify the path beyond expanding tildes and normalizing the path.  It only can work if given as absolute path or if the file is in cwd of process executing the library code.

With this PR, if we try to load the file and it doesn't exist, we will try it again as a path in the rcfile directory.  This will work in most cases of a relative path and follows the same algorithm as TaskWarrior itself (partial implementation: TaskWarrior also tries other places, see commit message for details).

Fixes #150

(superseded by #170)