### PR TITLE
Add compatibility with Taskwarrior 2.6.0

### DIFF
--- a/taskw/test/test_recursive.py
+++ b/taskw/test/test_recursive.py
@@ -60,4 +60,4 @@ class TestRecursibe(object):
         task2 = self.tw.task_add('task2')
         depends = [task1['uuid'], task2['uuid']]
         task3 = self.tw.task_add('task3', depends=depends)
-        assert task3['depends'] == [task1['uuid'], task2['uuid']]
+        assert set(task3['depends']) == set([task1['uuid'], task2['uuid']])

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -629,8 +629,7 @@ class TaskWarriorShellout(TaskWarriorBase):
         """
         query_args = taskw.utils.encode_query(filter_dict, self.get_version())
         return self._get_task_objects(
-            *query_args,
-            'export'
+            *(query_args + ['export'])
         )
 
     def get_task(self, **kw):
@@ -668,7 +667,7 @@ class TaskWarriorShellout(TaskWarriorBase):
             else:
                 search = [value]
 
-        task = self._get_task_objects(*search, 'export')
+        task = self._get_task_objects(*(search + ['export']))
 
         if task:
             if isinstance(task, list):

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -629,8 +629,8 @@ class TaskWarriorShellout(TaskWarriorBase):
         """
         query_args = taskw.utils.encode_query(filter_dict, self.get_version())
         return self._get_task_objects(
-            'export',
-            *query_args
+            *query_args,
+            'export'
         )
 
     def get_task(self, **kw):
@@ -668,7 +668,7 @@ class TaskWarriorShellout(TaskWarriorBase):
             else:
                 search = [value]
 
-        task = self._get_task_objects('export', *search)
+        task = self._get_task_objects(*search, 'export')
 
         if task:
             if isinstance(task, list):


### PR DESCRIPTION
This MR ensures that query filter precedes the command in `task export` invocations, which is required syntax in 2.6.0 and above (see https://github.com/GothenburgBitFactory/taskwarrior/pull/2576 for motivation).

Additionally fixes a test that relied on internal behaviour of dependency ordering.
