### PR TITLE
Remove obsolete 'priority' built-in field.

### DIFF
--- a/taskw/task.py
+++ b/taskw/task.py
@@ -39,11 +39,6 @@ class Task(dict):
         'mask': StringField(label='Mask', read_only=True),
         'modified': DateField(label='Modified'),
         'parent': StringField(label='Parent'),
-        'priority': ChoiceField(
-            choices=[None, 'H', 'M', 'L', ],
-            case_sensitive=False,
-            label='Priority'
-        ),
         'project': StringField(label='Project'),
         'recur': DurationField(label='Recurrence'),
         'scheduled': DateField(label='Scheduled'),


### PR DESCRIPTION
As long ago as Taskwarrior 2.4.3, the `priority` field is no longer a built-in field (https://taskwarrior.org/docs/priority.html), and should users re-define `priority` as a UDA having values other than `H`, `M`, and `L` while the aforementioned field definition is in place, an exception will be raised when deserializing:

```
Traceback (most recent call last):
  ...
  File "/src/taskw/taskw/task.py", line 197, in serialized
    serialized[k] = self._serialize(k, v, self._fields)
  File "/src/taskw/taskw/task.py", line 116, in _serialize
    return converter.serialize(value)
  File "/src/taskw/taskw/fields/choice.py", line 34, in serialize
    raise ValueError(
ValueError: '0' is not a valid choice; choices: [None, 'H', 'M', 'L']
```