### PR TITLE
Use field `read_only` attribute to determine which fields should be included in `task_update` call.

### DIFF
--- a/taskw/task.py
+++ b/taskw/task.py
@@ -62,7 +62,7 @@ class Task(dict):
         'tags': ArrayField(label='Tags'),
         'until': DateField(label='Until'),
         'urgency': NumericField(label='Urgency', read_only=True),
-        'uuid': UUIDField(label='UUID'),
+        'uuid': UUIDField(label='UUID', read_only=True),
         'wait': DateField(label='Wait'),
     }
 
@@ -206,11 +206,12 @@ class Task(dict):
         """ Set a key's value regardless of whether a change is seen."""
         return self.__setitem__(key, value, force=True)
 
-    def serialized(self):
+    def serialized(self, include_immutable=True):
         """ Returns a serialized representation of this task."""
         serialized = {}
         for k, v in six.iteritems(self):
-            serialized[k] = self._serialize(k, v, self._fields)
+            if include_immutable or self._field_is_writable(k):
+                serialized[k] = self._serialize(k, v, self._fields)
         return serialized
 
     def serialized_changes(self, keep=False):

--- a/taskw/task.py
+++ b/taskw/task.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import os
 import sys
+from typing import Dict
 
 from taskw.fields import (
     AnnotationArrayField,
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class Task(dict):
-    FIELDS = {
+    FIELDS: Dict[str, Field] = {
         'annotations': AnnotationArrayField(label='Annotations'),
         'depends': CommaSeparatedUUIDField(label='Depends Upon'),
         'description': StringField(label='Description'),
@@ -60,7 +60,7 @@ class Task(dict):
         'tags': ArrayField(label='Tags'),
         'until': DateField(label='Until'),
         'urgency': NumericField(label='Urgency', read_only=True),
-        'uuid': UUIDField(label='UUID', read_only=True),
+        'uuid': UUIDField(label='UUID'),
         'wait': DateField(label='Wait'),
     }
 

--- a/taskw/test/test_datas.py
+++ b/taskw/test/test_datas.py
@@ -143,29 +143,17 @@ class _BaseTestDB(object):
 
         tasks = self.tw.load_tasks()
         assert len(tasks['pending']) == 1
-        assert tasks['pending'][0]['priority'] == 'L'
 
-        # For compatibility with the direct and shellout modes.
-        # Shellout returns more information.
-        try:
-            # Shellout mode returns the correct urgency, so,
-            # let's just not compare for now.
-            del tasks['pending'][0]['urgency']
-            del task['urgency']
+        updated_task = tasks['pending'][0]
+        assert updated_task['priority'] == 'L'
 
-            # Also, experimental mode returns the id.  So, avoid comparing.
-            del tasks['pending'][0]['id']
+        calculated_fields = ['urgency', 'id', 'modified']
+        for field_name in calculated_fields:
+            for record in [task, updated_task]:
+                if field_name in record:
+                    del record[field_name]
 
-            # Task 2.2.0 adds a "modified" field, so delete this.
-            del tasks['pending'][0]['modified']
-        except Exception:
-            pass
-
-        # But Task 2.4.0 puts the modified field in earlier
-        if 'modified' in task:
-            del task['modified']
-
-        assert tasks['pending'][0] == task
+        assert updated_task == task
 
     def test_update_exc(self):
         task = dict(description="lol")

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -759,20 +759,14 @@ class TaskWarriorShellout(TaskWarriorBase):
         if isinstance(task, Task):
             # Let's pre-serialize taskw.task.Task instances
             task_uuid = six.text_type(task['uuid'])
-            task = task.serialized_changes(keep=True)
+            task = task.serialized_changes(keep=True, include_immutable=False)
             legacy = False
         else:
             task_uuid = task['uuid']
 
-        id, original_task = self.get_task(uuid=task_uuid)
-
-        if 'id' in task:
-            del task['id']
+        _, original_task = self.get_task(uuid=task_uuid)
 
         task_to_modify = copy.deepcopy(task)
-
-        task_to_modify.pop('uuid', None)
-        task_to_modify.pop('id', None)
 
         # Only handle annotation differences if this is an old-style
         # task, or if the task itself says annotations have changed.
@@ -798,9 +792,6 @@ class TaskWarriorShellout(TaskWarriorBase):
 
             if 'annotations' in task_to_modify:
                 del task_to_modify['annotations']
-
-        if task_to_modify.get('urgency') == 0:
-            del task_to_modify['urgency']
 
         modification = taskw.utils.encode_task_experimental(task_to_modify)
         # Only try to modify the task if there are changes to post here

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -763,7 +763,7 @@ class TaskWarriorShellout(TaskWarriorBase):
         if isinstance(task, Task):
             # Let's pre-serialize taskw.task.Task instances
             task_uuid = str(task['uuid'])
-            task = task.serialized_changes(keep=True, include_immutable=False)
+            task = task.serialized_changes(keep=True)
             legacy = False
         else:
             task_uuid = task['uuid']
@@ -771,6 +771,12 @@ class TaskWarriorShellout(TaskWarriorBase):
         _, original_task = self.get_task(uuid=task_uuid)
 
         task_to_modify = copy.deepcopy(task)
+
+        read_only_fields = [
+            k for (k, v) in Task.FIELDS.items() if v.read_only
+        ] + ['uuid']  # 'uuid' isn't always read-only, but is during an update
+        for field_name in read_only_fields:
+            task_to_modify.pop(field_name, None)
 
         # Only handle annotation differences if this is an old-style
         # task, or if the task itself says annotations have changed.

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -799,6 +799,9 @@ class TaskWarriorShellout(TaskWarriorBase):
             if 'annotations' in task_to_modify:
                 del task_to_modify['annotations']
 
+        if task_to_modify.get('urgency') == 0:
+            del task_to_modify['urgency']
+
         modification = taskw.utils.encode_task_experimental(task_to_modify)
         # Only try to modify the task if there are changes to post here
         # (changes *might* just be in annotations).


### PR DESCRIPTION
We've historically had a list of fields we'd carefully remember to pop off of our task object before performing an update operation.  We've also historically had a list of fields including whether those fields are `read_only` or not for use during serialization/deserialization of data. Let's just use that metadata for determining which fields are mutable and which aren't when performing a `task_update` operation.