### PR TITLE
Drops support for Python 3.5 (eol'd as of 13 Sept 2020).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         taskwarrior-version: [2.5.0, 2.5.1, 2.5.3]
         exclude:
-          # Taskwarriror 3.5.3 only supported on Python 3.7+.
-          - python-version: 3.5
-            taskwarrior-version: 2.5.3
+          # Taskwarriror 2.5.3 only supported on Python 3.7+.
           - python-version: 3.6
             taskwarrior-version: 2.5.3
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ downloadcache = {toxworkdir}/_download/
 
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
Python 3.5 support was EOL'd on 13 September 2020 (see https://endoflife.date/python) and maintaining support for it prevents us from using several nice typing features available in later versions of Python (specifically: type annotations for variables, e.g.: https://github.com/ralphbean/taskw/runs/4915784147?check_suite_focus=true).

I'm also tempted to drop 3.6 support, too, given that it is also past its EOL date and would allow us to use things like forward references and dataclasses, but since it has only been past its EOL for a month, I don't want to do that without some discussion with the other maintainers.