### PR TITLE
make `TaskWarriorShellout()` do `task --version` only once

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -561,8 +561,10 @@ class TaskWarriorShellout(TaskWarriorBase):
 
     @classmethod
     def get_version(cls):
+        if hasattr(cls, 'taskwarrior_version'):
+            return cls.taskwarrior_version
         try:
-            taskwarrior_version = subprocess.Popen(
+            taskwver = subprocess.Popen(
                 ['task', '--version'],
                 stdout=subprocess.PIPE
             ).communicate()[0]
@@ -570,7 +572,8 @@ class TaskWarriorShellout(TaskWarriorBase):
             raise FileNotFoundError(
                 "Unable to find the 'task' command-line tool."
             )
-        return LooseVersion(taskwarrior_version.decode())
+        cls.taskwarrior_version = LooseVersion(taskwver.decode())
+        return cls.taskwarrior_version
 
     def sync(self, init=False):
         if self.get_version() < LooseVersion('2.3'):


### PR DESCRIPTION
`TaskWarriorShellout()` is doing at least 3 `task --version` to get the instance (before we can run any methods), and then is doing these calls again for each `filter_task()`, `task_add()`, or `sync()` method call.

This patch moves `task --version` execution to a cached class attribute so it can be done one time only during the lifetime.

Note that we cannot move this to instance constructor because it's run during module import at toplevel (via `.can_use()` call at bottom of `taskw/warrior.py`)

Fixes #158

Thanks also to @ryneeverett for suggesting use a cached class attribute in get_version()