### PR TITLE
Add duration serializer, deserializer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,5 @@ jobs:
         python -m pip install pytest
     - name: Run Tests
       run: |
+        cp taskw/test/data/test.taskrc ~/.taskrc
         pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         cd taskwarrior
         git checkout v${{matrix.taskwarrior-version}}
         cmake .
-        make
+        make -j
         sudo make install
         task --version
         cd ../

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
-norecursedirs=lib
-addopts = -p no:warnings --doctest-modules
+norecursedirs=lib taskwarrior
+addopts = -p no:warnings --doctest-modules -v

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
 norecursedirs=lib
-addopts = -p no:warnings
+addopts = -p no:warnings --doctest-modules

--- a/taskw/fields/duration.py
+++ b/taskw/fields/duration.py
@@ -1,10 +1,121 @@
-from .string import StringField
+from datetime import timedelta
+from typing import Dict, Optional, Tuple
+from .base import Field
 
 
-class DurationField(StringField):
-    """ In the future this will handle transforming recurrence patterns.
-
-    See https://github.com/taskwarrior/task/blob/2.3.0/src/Duration.cpp#L41
-
+def extract_part(s: str, split: str) -> Tuple[float, str]:
     """
-    pass
+    Return the integer value for the given split (e.g., H, M, ...), along with the remainder of
+    the string after extracting this part
+
+    .. warning:: The functiona assumes that you're parsing the string in a sequential function.
+    It doesn't take into account that there may be two "M" (for months and minutes) inside the
+    string and will split it based on the first one it finds.
+
+    >>> extract_part("3Y6M4DT12H30M5S", "Y")
+    (3.0, '6M4DT12H30M5S')
+    >>> extract_part("6M4DT12H30M5S", "M")
+    (6.0, '4DT12H30M5S')
+    >>> extract_part("4DT12H30M5S", "D")
+    (4.0, 'T12H30M5S')
+    >>> extract_part("12H30M5S", "H")
+    (12.0, '30M5S')
+    >>> extract_part("30M5S", "M")
+    (30.0, '5S')
+    >>> extract_part("5S", "S")
+    (5.0, '')
+    >>> extract_part("5S", "M")
+    (0, '5S')
+    >>> extract_part("123456S", "S")
+    (123456.0, '')
+    """
+
+    if split in s:
+        n, s = s.split(split, maxsplit=1)
+        n = float(n)
+    else:
+        n = 0
+
+    return n, s
+
+
+def parse_iso8601_duration(string: str) -> timedelta:
+    """
+    Parse durations in the ISO 8601 format.
+
+    >>> round(parse_iso8601_duration("PT30S").total_seconds(), 2) == round(30.0, 2)
+    True
+    >>> int(parse_iso8601_duration("P1DT30S").total_seconds()) == 24*60*60 + 30
+    True
+    >>> round(parse_iso8601_duration("P1MT").total_seconds(), 2) == round(30.5*24*60*60, 2)
+    True
+    >>> parse_iso8601_duration("P349700DT6H27M21S")
+    datetime.timedelta(days=349700, seconds=23241)
+    """
+    orig_string = string
+    if not string.startswith("P"):
+        raise ValueError(
+            f'{orig_string} is not an ISO8601 duration, expected to find the "P" character at the start'
+        )
+    if "T" not in string:
+        raise ValueError(
+            f'{orig_string} is not an ISO8601 duration, expected to find the "T" character'
+        )
+    string = string[1:]
+
+    fields_before_t: Dict[str, float] = {"Y": 0, "M": 0, "D": 0}
+
+    # Step through letter dividers
+    for field_name in fields_before_t.keys():
+        if string.startswith("T"):
+            break
+
+        try:
+            T_index=string.index("T")
+        except ValueError:
+            T_index=len(string)
+
+        fields_before_t[field_name], string0 = extract_part(string[0:T_index], field_name)
+        string = f"{string0}{string[T_index:]}"
+
+    if not string.startswith("T"):
+        raise ValueError(
+            f'{orig_string} is not an ISO8601 duration, expected to find the "T" character before parsing days/minutes/seconds'
+        )
+    string = string[1:]
+
+    hours, string = extract_part(string, "H")
+    minutes, string = extract_part(string, "M")
+    seconds, string = extract_part(string, "S")
+
+    # rough conversion if years and months are given
+    days = fields_before_t["D"]
+    days += fields_before_t["M"] * 30.5
+    days += fields_before_t["Y"] * 365
+
+    # assemble the duration
+    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+class DurationField(Field):
+    def deserialize(self, value: Optional[str]) -> Optional[timedelta]:
+        if value is None:
+            return None
+
+        return parse_iso8601_duration(value)
+
+    def serialize(self, value: Optional[timedelta]) -> Optional[str]:
+        """
+        >>> field = DurationField()
+        >>> field.serialize(timedelta(days=300))
+        'PT25920000S'
+        >>> field.serialize(timedelta(minutes=3))
+        'PT180S'
+        """
+        if value is None:
+            return None
+
+        # TODO atm (220220529) taskwarrior does not support float notation for its fields (i.e., the
+        # following throws an exception on the CLI (task 734 mod durationuda:PT10M5.2S)
+        # I'm converting it all  to seconds
+        return f"PT{int(value.total_seconds())}S"

--- a/taskw/fields/duration.py
+++ b/taskw/fields/duration.py
@@ -55,15 +55,19 @@ def parse_iso8601_duration(string: str) -> timedelta:
     orig_string = string
     if not string.startswith("P"):
         raise ValueError(
-            f'{orig_string} is not an ISO8601 duration, expected to find the "P" character at the start'
+            '{} is not an ISO8601 duration, expected to find the "P" character at the start'.format(
+                orig_string
+            )
         )
     if "T" not in string:
         raise ValueError(
-            f'{orig_string} is not an ISO8601 duration, expected to find the "T" character'
+            '{} is not an ISO8601 duration, expected to find the "T" character'.format(
+                orig_string
+            )
         )
     string = string[1:]
 
-    fields_before_t: Dict[str, float] = {"Y": 0, "M": 0, "D": 0}
+    fields_before_t = {"Y": 0, "M": 0, "D": 0}
 
     # Step through letter dividers
     for field_name in fields_before_t.keys():
@@ -71,16 +75,18 @@ def parse_iso8601_duration(string: str) -> timedelta:
             break
 
         try:
-            T_index=string.index("T")
+            T_index = string.index("T")
         except ValueError:
-            T_index=len(string)
+            T_index = len(string)
 
         fields_before_t[field_name], string0 = extract_part(string[0:T_index], field_name)
         string = f"{string0}{string[T_index:]}"
 
     if not string.startswith("T"):
         raise ValueError(
-            f'{orig_string} is not an ISO8601 duration, expected to find the "T" character before parsing days/minutes/seconds'
+            '{} is not an ISO8601 duration, expected to find the "T" character before parsing days/minutes/seconds'.format(
+                    orig_string
+            )
         )
     string = string[1:]
 

--- a/taskw/fields/duration.py
+++ b/taskw/fields/duration.py
@@ -49,8 +49,11 @@ def parse_iso8601_duration(string: str) -> timedelta:
     True
     >>> round(parse_iso8601_duration("P1MT").total_seconds(), 2) == round(30.5*24*60*60, 2)
     True
-    >>> parse_iso8601_duration("P349700DT6H27M21S")
-    datetime.timedelta(days=349700, seconds=23241)
+    >>> dt = parse_iso8601_duration("P349700DT6H27M21S")
+    >>> dt.days
+    349700
+    >>> dt.seconds
+    23241
     """
     orig_string = string
     if not string.startswith("P"):
@@ -67,7 +70,7 @@ def parse_iso8601_duration(string: str) -> timedelta:
         )
     string = string[1:]
 
-    fields_before_t = {"Y": 0, "M": 0, "D": 0}
+    fields_before_t = {"Y": 0.0, "M": 0.0, "D": 0.0}
 
     # Step through letter dividers
     for field_name in fields_before_t.keys():
@@ -80,7 +83,7 @@ def parse_iso8601_duration(string: str) -> timedelta:
             T_index = len(string)
 
         fields_before_t[field_name], string0 = extract_part(string[0:T_index], field_name)
-        string = f"{string0}{string[T_index:]}"
+        string = "{}{}".format(string0, string[T_index:])
 
     if not string.startswith("T"):
         raise ValueError(
@@ -124,4 +127,4 @@ class DurationField(Field):
         # TODO atm (220220529) taskwarrior does not support float notation for its fields (i.e., the
         # following throws an exception on the CLI (task 734 mod durationuda:PT10M5.2S)
         # I'm converting it all  to seconds
-        return f"PT{int(value.total_seconds())}S"
+        return "PT{}S".format(int(value.total_seconds()))

--- a/taskw/task.py
+++ b/taskw/task.py
@@ -43,7 +43,9 @@ class Task(dict):
             label='Priority'
         ),
         'project': StringField(label='Project'),
-        'recur': DurationField(label='Recurrence'),
+        # TODO Convert this to a DurationField, handle values like "monthly" and "daily"
+        # explicitly
+        'recur': StringField(label='Recurrence'),
         'scheduled': DateField(label='Scheduled'),
         'start': DateField(label='Started'),
         'status': ChoiceField(

--- a/taskw/test/data/test.taskrc
+++ b/taskw/test/data/test.taskrc
@@ -1,0 +1,1 @@
+data.location = ~/.task

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -117,12 +117,12 @@ class TaskWarriorBase(metaclass=abc.ABCMeta):
 
         >>> w = TaskWarrior()
         >>> tasks = w.load_tasks()
-        >>> tasks.keys()
-        ['completed', 'pending']
-        >>> type(tasks['pending'])
-        <type 'list'>
-        >>> type(tasks['pending'][0])
-        <type 'dict'>
+        >>> list(tasks.keys())
+        ['pending', 'completed']
+        >>> isinstance(tasks['pending'], list)
+        True
+        >>> isinstance(tasks['pending'][0], dict)
+        True
         """
 
     @abc.abstractmethod
@@ -164,10 +164,7 @@ class TaskWarriorBase(metaclass=abc.ABCMeta):
 
         >>> config = TaskWarrior.load_config()
         >>> config['data']['location']
-        '/home/threebean/.task'
-        >>> config['_forcecolor']
-        'yes'
-
+        '~/.task'
         """
         return TaskRc(config_filename, overrides=overrides)
 

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -117,11 +117,12 @@ class TaskWarriorBase(metaclass=abc.ABCMeta):
 
         >>> w = TaskWarrior()
         >>> tasks = w.load_tasks()
-        >>> list(tasks.keys())
-        ['pending', 'completed']
-        >>> isinstance(tasks['pending'], list)
+        >>> li = list(tasks.keys())
+        >>> "pending" in li
         True
-        >>> isinstance(tasks['pending'][0], dict)
+        >>> "completed" in li
+        True
+        >>> isinstance(tasks['pending'], list)
         True
         """
 


### PR DESCRIPTION
Hi @ralphbean ,

This PR adds serdes functions for the Duration class. I decided to implement them in [taskwarrior_syncall](https://github.com/bergercookie/taskwarrior_syncall) so I thought of pushing them to this project ^^

* The format for the duration field is described albeit briefly, [here](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)

Additional changes:

* fixes some failing doctests in warrior.py and also enabling checking the doctests as part of `setup.cfg`.
* disables running pytest on the taskwarrior/ directory which is downloaded automatically during CI.
* Enables `make -j` to speed up the CI process

