### PR TITLE
Taskrc discovery: check ${XDG_CONFIG_DIR}/task/taskrc; raise execption if not found

### DIFF
--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -47,11 +47,13 @@ def find_taskrc():
         else:
             raise FileNotFoundError("Environment variable 'TASKRC' did not resolve to a taskrc file")
 
-    taskrc = Path("~/.taskrc")
+    home_dir = Path.home()
+
+    taskrc = home_dir / ".taskrc"
     if taskrc.is_file():
         return taskrc
 
-    taskrc = Path("~/.config/task/taskrc")
+    taskrc = home_dir / ".config/task/taskrc"
     if taskrc.is_file():
         return taskrc
 

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -55,8 +55,8 @@ def find_taskrc():
     if taskrc.is_file():
         return taskrc
  
-    if "XDG_CONFIG_DIR" in os.environ.keys():
-        taskrc = Path(os.environ["XDG_CONFIG_DIR"]) / "task/taskrc"
+    if "XDG_CONFIG_HOME" in os.environ.keys():
+        taskrc = Path(os.environ["XDG_CONFIG_HOME"]) / "task/taskrc"
         if taskrc.is_file():
             return taskrc
 

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -37,23 +37,25 @@ def find_taskrc():
     """
     Find the location of the taskwarrior configuration file.
 
-    First checks ${TASKRC} environment variable, then falls back to ~/.taskrc and finally ${XDG_CONFIG_DIR}/task/taskrc.
+    Follows Taskwarrior's config discovery order
+    * ${HOME}/.taskrc
+    * ${TASKRC}
+    * ${XDG_CONFIG_HOME}/task/taskrc
 
     Raises FileNotFoundError if either
       * Specified taskrc is not a file
       * No taskrc was found
     """
+    taskrc = Path.home() / ".taskrc"
+    if taskrc.is_file():
+        return taskrc.as_posix()
+
     if "TASKRC" in os.environ:
         taskrc = Path(os.environ["TASKRC"])
         if taskrc.is_file():
             return taskrc.as_posix()
         else:
-            raise FileNotFoundError("Environment variable 'TASKRC' did not resolve to a taskrc file")
-
-
-    taskrc = Path.home() / ".taskrc"
-    if taskrc.is_file():
-        return taskrc.as_posix()
+            raise FileNotFoundError("Environment variable 'TASKRC' did not resolve to a taskrc file") 
  
     if "XDG_CONFIG_HOME" in os.environ.keys():
         taskrc = Path(os.environ["XDG_CONFIG_HOME"]) / "task/taskrc"

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -35,10 +35,9 @@ logger = logging.getLogger(__name__)
 
 def find_taskrc():
     """
-    Find the location of configuration file.
+    Find the location of the taskwarrior configuration file.
 
-    First checks TASKRC environment variable, then falls back to ~/.taskrc and finally ~/.config/task/taskrc.
-
+    First checks ${TASKRC} environment variable, then falls back to ~/.taskrc and finally ${XDG_CONFIG_DIR}/task/taskrc.
     """
     if "TASKRC" in os.environ.keys():
         taskrc = Path(os.environ["TASKRC"])
@@ -47,15 +46,15 @@ def find_taskrc():
         else:
             raise FileNotFoundError("Environment variable 'TASKRC' did not resolve to a taskrc file")
 
-    home_dir = Path.home()
 
-    taskrc = home_dir / ".taskrc"
+    taskrc = Path.home() / ".taskrc"
     if taskrc.is_file():
         return taskrc
-
-    taskrc = home_dir / ".config/task/taskrc"
-    if taskrc.is_file():
-        return taskrc
+ 
+    if "XDG_CONFIG_DIR" in os.environ.keys():
+        taskrc = Path(os.environ["XDG_CONFIG_DIR"]) / "task/taskrc"
+        if taskrc.is_file():
+            return taskrc
 
     raise FileNotFoundError("Unable to find taskrc. Set environment variable 'TASKRC=<file>' for a non-standard location")
     

--- a/taskw/warrior.py
+++ b/taskw/warrior.py
@@ -38,6 +38,10 @@ def find_taskrc():
     Find the location of the taskwarrior configuration file.
 
     First checks ${TASKRC} environment variable, then falls back to ~/.taskrc and finally ${XDG_CONFIG_DIR}/task/taskrc.
+
+    Raises FileNotFoundErrors if either
+      * Specified taskrc is not a file
+      * No taskrc was found
     """
     if "TASKRC" in os.environ.keys():
         taskrc = Path(os.environ["TASKRC"])


### PR DESCRIPTION
I have my taskrc in `${XDG_CONFIG_HOME}/task/taskrc`, a location that taskwarrior checks by default. Since this is a default location, I would like to add support to `taskw` to check without needing to set the TASKRC env var.

I've added a function, `find_taskrc()`, that checks these locations, in this order:
1. `${TASKRC}` env var
2. `${HOME}/.taskrc` 
3. `${XDG_CONFIG_HOME}/task/taskrc`

Additionally, this function raises `FileNotFoundError` when either
* the found taskrc path is not a file
* no taskrc path could be found

I'm happy to make changes to get the basic idea of searching `${XDG_CONFIG_HOME}/task/taskrc` in.
