### PR TITLE
Fix tests with new pytest

### DIFF
--- a/taskw/test/test_datas.py
+++ b/taskw/test/test_datas.py
@@ -6,6 +6,7 @@ import dateutil.tz
 
 import pytest
 
+from unittest import TestCase
 from taskw import TaskWarriorDirect, TaskWarriorShellout
 
 
@@ -16,8 +17,9 @@ TASK = {'description': "task 2 http://www.google.com/",
         'uuid': "c1c431ea-f0dc-4683-9a20-e64fcfa65fd1"}
 
 
-class _BaseTestDB(object):
-    def setup(self):
+class _BaseTestDB(TestCase):
+    __test__ = False
+    def setUp(self):
 
         # Sometimes the 'task' command line tool is not installed.
         if self.should_skip():
@@ -330,6 +332,7 @@ class _BaseTestDB(object):
 
 
 class TestDBDirect(_BaseTestDB):
+    __test__ = True
     class_to_test = TaskWarriorDirect
 
     def test_delete_completed(self):
@@ -345,6 +348,7 @@ class TestDBDirect(_BaseTestDB):
 
 
 class TestDBShellout(_BaseTestDB):
+    __test__ = True
     class_to_test = TaskWarriorShellout
 
     def should_skip(self):

--- a/taskw/test/test_recursive.py
+++ b/taskw/test/test_recursive.py
@@ -4,6 +4,7 @@ import tempfile
 
 import pytest
 
+from unittest import TestCase
 from taskw import TaskWarriorShellout
 
 
@@ -14,8 +15,8 @@ TASK = {'description': "task 2 http://www.google.com/",
         'uuid': "c1c431ea-f0dc-4683-9a20-e64fcfa65fd1"}
 
 
-class TestRecursibe(object):
-    def setup(self):
+class TestRecursibe(TestCase):
+    def setUp(self):
         if not TaskWarriorShellout.can_use():
             # Sometimes the 'task' command line tool is not installed.
             pytest.skip("taskwarrior not installed")

--- a/taskw/test/test_utils.py
+++ b/taskw/test/test_utils.py
@@ -4,6 +4,7 @@ import random
 import dateutil.tz
 import pytz
 
+from unittest import TestCase
 from taskw.utils import (
     convert_dict_to_override_args,
     decode_task,
@@ -31,7 +32,7 @@ def shuffled(l):
     return new
 
 
-class TestUtils(object):
+class TestUtils(TestCase):
 
     def test_no_side_effects(self):
         orig = TASK.copy()
@@ -187,7 +188,7 @@ class TestUtils(object):
         assert set(actual_overrides) == set(expected_overrides)
 
 
-class TestCleanExecArg(object):
+class TestCleanExecArg(TestCase):
     def test_clean_null(self):
         assert b"" == clean_ctrl_chars(b"\x00")
 


### PR DESCRIPTION
Use unittest.TestCase and __test__ to ignore test base class.